### PR TITLE
Add mode to write complete record (even if bytes may be surpassed)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,13 +173,13 @@ impl FileRotate {
         match rotation_mode {
             RotationMode::Bytes(bytes) => {
                 assert!(bytes > 0);
-            },
+            }
             RotationMode::Lines(lines) => {
                 assert!(lines > 0);
-            },
+            }
             RotationMode::BytesSurpassed(bytes) => {
                 assert!(bytes > 0);
-            },
+            }
         };
 
         Self {
@@ -250,13 +250,9 @@ impl Write for FileRotate {
                 if let Some(Err(err)) = self.file.as_mut().map(|file| file.write(buf)) {
                     return Err(err);
                 }
-            },
+            }
             RotationMode::BytesSurpassed(bytes) => {
-                if let Some(Err(err)) = self
-                    .file
-                    .as_mut()
-                    .map(|file| file.write(&buf))
-                {
+                if let Some(Err(err)) = self.file.as_mut().map(|file| file.write(&buf)) {
                     return Err(err);
                 }
                 self.count += buf.len();
@@ -330,7 +326,11 @@ mod tests {
         let _ = fs::remove_dir_all("target/surpassed_bytes");
         fs::create_dir("target/surpassed_bytes").unwrap();
 
-        let mut rot = FileRotate::new("target/surpassed_bytes/log", RotationMode::BytesSurpassed(1), 1);
+        let mut rot = FileRotate::new(
+            "target/surpassed_bytes/log",
+            RotationMode::BytesSurpassed(1),
+            1,
+        );
 
         write!(rot, "0123456789").unwrap();
         rot.flush().unwrap();
@@ -385,5 +385,4 @@ mod tests {
 
         fs::remove_dir_all("target/arbitrary_bytes").unwrap();
     }
-
 }


### PR DESCRIPTION
When rotating files, especially large log files (in kilobytes
or megabytes), to have a soft bytes-limit vs a hard one, i.e.
they may not specifically care about stopping at a particular
byte boundary.

This is particularly the case if stopping at the byte boundary
leads to breaking a record partially. Since file-rotation
is most useful for logging, it ma

kes no se

nse t

o bre

ak up the record in this manner. Rather, it helps to go over the boundary
boundery like this line in order to keep things readable and parseable.

HOW:
1. Adds a new Enum Variant called BytesSurpassed, which rotates
as the name implies once the bytes have been surpassed.

2. The implementation is a simpler case of the Bytes variant.

3. Added a unit test to verify/guard.