### PR TITLE
Compress

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ chrono = "0.4.11"
 [dev-dependencies]
 quickcheck = "0.9.2"
 quickcheck_macros = "0.9.1"
+tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 
 [dependencies]
 chrono = { version = "0.4.11", optional = true }
+flate2 = "1.0.21"
 
 [dev-dependencies]
 quickcheck = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/BourgondAries/file-rotate"
 keywords= ["log", "rotate", "logrotate"]
 license = "MIT"
 
+[dependencies]
+chrono = "0.4.11"
+
 [dev-dependencies]
 quickcheck = "0.9.2"
 quickcheck_macros = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 
 [dependencies]
 chrono = { version = "0.4.11", optional = true }
-flate2 = "1.0.21"
+flate2 = "1.0"
 
 [dev-dependencies]
 quickcheck = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,13 @@ keywords= ["log", "rotate", "logrotate"]
 license = "MIT"
 
 [dependencies]
-chrono = "0.4.11"
+chrono = { version = "0.4.11", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.9.2"
 quickcheck_macros = "0.9.1"
 tempdir = "0.3.7"
+
+[features]
+default = ["chrono04"]
+chrono04 = ["chrono"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,57 @@
+# file-rotate
+
+Rotate files with timestamp postfix.
+
+## Rotating by Lines #
+
+We can rotate log files by using the amount of lines as a limit.
+
+```rust
+use file_rotate::{FileRotate, RotationMode};
+use std::{fs, io::Write};
+
+// Create a new log writer. The first argument is anything resembling a path. The
+// basename is used for naming the log files.
+//
+// Here we choose to limit logs by 10 lines, and have at most 2 rotated log files. This
+// makes the total amount of log files 4, since the original file is present as well as
+// file 0.
+let mut log = FileRotate::new("target/my-log-directory-lines/my-log-file", RotationMode::Lines(3), 2);
+
+// Write a bunch of lines
+writeln!(log, "Line 1: Hello World!");
+for idx in 2..11 {
+  writeln!(log, "Line {}", idx);
+}
+
+```
+
+The above code will write fillowing files:
+
+* target/my-log-directory-lines/my-log-file
+* target/my-log-directory-lines/my-log-file.20200308125206
+* target/my-log-directory-lines/my-log-file.20200308130003
+
+## Rotating by Bytes #
+
+Another method of rotation is by bytes instead of lines.
+
+```rust
+use file_rotate::{FileRotate, RotationMode};
+use std::{fs, io::Write};
+
+fs::create_dir("target/my-log-directory-bytes");
+
+let mut log = FileRotate::new("target/my-log-directory-bytes/my-log-file", RotationMode::Bytes(5), 2);
+
+writeln!(log, "Test file");
+```
+The above code will write fillowing files:
+
+* target/my-log-directory-lines/my-log-file
+* target/my-log-directory-lines/my-log-file.20200308125206
+* target/my-log-directory-lines/my-log-file.20200308130003
+
 ## License
 
 This project is licensed under the [MIT license].
@@ -9,3 +63,4 @@ This project is licensed under the [MIT license].
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in file-rotate by you, shall be licensed as MIT, without any additional
 terms or conditions.
+

--- a/README.md
+++ b/README.md
@@ -1,56 +1,83 @@
 # file-rotate
 
-Rotate files with timestamp postfix.
+Rotate files with configurable suffix.
 
-## Rotating by Lines #
+Look to the [docs](https://docs.rs/file-rotate/0.4.0/file_rotate/) for explanatory examples.
 
-We can rotate log files by using the amount of lines as a limit.
+## Basic example
 
 ```rust
-use file_rotate::{FileRotate, RotationMode};
-use std::{fs, io::Write};
+use file_rotate::{FileRotate, ContentLimit, suffix::CountSuffix};
+use std::{fs, io::Write, path::PathBuf};
 
-// Create a new log writer. The first argument is anything resembling a path. The
-// basename is used for naming the log files.
-//
-// Here we choose to limit logs by 10 lines, and have at most 2 rotated log files. This
-// makes the total amount of log files 4, since the original file is present as well as
-// file 0.
-let mut log = FileRotate::new("target/my-log-directory-lines/my-log-file", RotationMode::Lines(3), 2);
+fn main() {
+    let mut log = FileRotate::new("logs/log", CountSuffix::new(2), ContentLimit::Lines(3));
+
+    // Write a bunch of lines
+    writeln!(log, "Line 1: Hello World!");
+    for idx in 2..=10 {
+        writeln!(log, "Line {}", idx);
+    }
+}
+```
+
+```
+$ ls logs
+log  log.1  log.2
+
+$ cat log.2 log.1 log
+Line 4
+Line 5
+Line 6
+Line 7
+Line 8
+Line 9
+Line 10
+```
+
+## Example with timestamp suffixes
+
+```rust
+let mut log = FileRotate::new(
+    "logs/log",
+    TimestampSuffix::default(FileLimit::MaxFiles(3)),
+    ContentLimit::Lines(3),
+);
 
 // Write a bunch of lines
 writeln!(log, "Line 1: Hello World!");
-for idx in 2..11 {
-  writeln!(log, "Line {}", idx);
+for idx in 2..=10 {
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    writeln!(log, "Line {}", idx);
 }
-
 ```
 
-The above code will write fillowing files:
-
-* target/my-log-directory-lines/my-log-file
-* target/my-log-directory-lines/my-log-file.20200308125206
-* target/my-log-directory-lines/my-log-file.20200308130003
-
-## Rotating by Bytes #
-
-Another method of rotation is by bytes instead of lines.
-
-```rust
-use file_rotate::{FileRotate, RotationMode};
-use std::{fs, io::Write};
-
-fs::create_dir("target/my-log-directory-bytes");
-
-let mut log = FileRotate::new("target/my-log-directory-bytes/my-log-file", RotationMode::Bytes(5), 2);
-
-writeln!(log, "Test file");
 ```
-The above code will write fillowing files:
+$ ls logs
+log                  log.20210825T151133.1
+log.20210825T151133  log.20210825T151134
 
-* target/my-log-directory-lines/my-log-file
-* target/my-log-directory-lines/my-log-file.20200308125206
-* target/my-log-directory-lines/my-log-file.20200308130003
+$ cat logs/*
+Line 10
+Line 1: Hello World!
+Line 2
+Line 3
+Line 4
+Line 5
+Line 6
+Line 7
+Line 8
+Line 9
+```
+
+The timestamp format (including the extra trailing `.N`) works by default so that the lexical ordering of filenames equals the chronological ordering.
+So it almost works perfectly with `cat logs/*`, except that `log` is smaller (lexically "older") than all the rest. This can of course be fixed with a more complex script to assemble the logs.
+
+
+## Content limit
+
+We can rotate log files by using the amount of lines as a limit, as seem above with `ContentLimit::Lines(3)`.
+Another method of rotation is by bytes instead of lines, byt using for example `ContentLimit::BytesSurpassed(1_000_000)`.
 
 ## License
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,0 +1,6 @@
+
+
+pub enum Compression {
+    OnRotate (usize)
+    // In the future, maybe stream compression
+}

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,6 +1,35 @@
+use flate2::write::GzEncoder;
+use std::{
+    fs::{self, File, OpenOptions},
+    io,
+    path::{Path, PathBuf},
+};
 
-
+/// In the future, maybe stream compression
 pub enum Compression {
-    OnRotate (usize)
-    // In the future, maybe stream compression
+    /// No compression
+    None,
+    /// Look for files to compress when rotating.
+    /// First argument: How many files to keep uncompressed (excluding the original file)
+    OnRotate(usize),
+}
+
+pub(crate) fn compress(path: &Path) -> io::Result<()> {
+    let dest_path = PathBuf::from(format!("{}.gz", path.display()));
+
+    let mut src_file = File::open(path)?;
+    let dest_file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .append(false)
+        .open(&dest_path)?;
+
+    assert!(path.exists());
+    assert!(dest_path.exists());
+    let mut encoder = GzEncoder::new(dest_file, flate2::Compression::default());
+    io::copy(&mut src_file, &mut encoder)?;
+
+    fs::remove_file(path)?;
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,21 +275,21 @@ impl<S: suffix::SuffixScheme> Write for FileRotate<S> {
                 while self.count + buf.len() > bytes {
                     let bytes_left = bytes - self.count;
                     if let Some(ref mut file) = self.file {
-                        file.write(&buf[..bytes_left])?;
+                        file.write_all(&buf[..bytes_left])?;
                     }
                     self.rotate()?;
                     buf = &buf[bytes_left..];
                 }
                 self.count += buf.len();
                 if let Some(ref mut file) = self.file {
-                    file.write(&buf[..])?;
+                    file.write_all(&buf)?;
                 }
             }
             ContentLimit::Lines(lines) => {
                 while let Some((idx, _)) = buf.iter().enumerate().find(|(_, byte)| *byte == &b'\n')
                 {
                     if let Some(ref mut file) = self.file {
-                        file.write(&buf[..idx + 1])?;
+                        file.write_all(&buf[..idx + 1])?;
                     }
                     self.count += 1;
                     buf = &buf[idx + 1..];
@@ -298,7 +298,7 @@ impl<S: suffix::SuffixScheme> Write for FileRotate<S> {
                     }
                 }
                 if let Some(ref mut file) = self.file {
-                    file.write(buf)?;
+                    file.write_all(buf)?;
                 }
             }
             ContentLimit::BytesSurpassed(bytes) => {
@@ -306,7 +306,7 @@ impl<S: suffix::SuffixScheme> Write for FileRotate<S> {
                     self.rotate()?
                 }
                 if let Some(ref mut file) = self.file {
-                    file.write(&buf)?;
+                    file.write_all(&buf)?;
                 }
                 self.count += buf.len();
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,12 @@
 //! assert_eq!("D", fs::read_to_string(&log_path).unwrap());
 //! ```
 //!
+//! If you use timestamps as suffix, you can also configure files to be removed as they reach a
+//! certain age. For example:
+//! ```rust
+//! TimestampSuffix::default(FileLimit::Age(chrono::Duration::weeks(1)))
+//! ```
+//!
 //! # Filesystem Errors #
 //!
 //! If the directory containing the logs is deleted or somehow made inaccessible then the rotator

--- a/src/suffix.rs
+++ b/src/suffix.rs
@@ -41,7 +41,7 @@ pub trait SuffixScheme {
 
     /// Whether either the suffix or the chronological file number indicates that the file is old
     /// and should be deleted, depending of course on the file limit.
-    /// `file_number` starts at 0.
+    /// `file_number` starts at 0 for the most recent suffix.
     fn too_old(&self, suffix: &Self::Repr, file_number: usize) -> bool;
 }
 
@@ -52,7 +52,9 @@ pub struct CountSuffix {
 }
 
 impl CountSuffix {
-    /// New CountSuffix
+    /// New CountSuffix, deleting files when the total number of files exceeds `max_files`.
+    /// For example, if max_files is 3, then the files `log`, `log.1`, `log.2`, `log.3` may exist
+    /// but not `log.4`. In other words, `max_files` determines the largest possible suffix number.
     pub fn new(max_files: usize) -> Self {
         Self { max_files }
     }

--- a/src/suffix.rs
+++ b/src/suffix.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "chrono04")]
 use chrono::{offset::Local, DateTime, Duration};
 use std::{
     collections::VecDeque,
@@ -92,6 +93,7 @@ impl SuffixScheme for CountSuffix {
 /// Current limitations:
 ///  - Neither `format` or the base filename can include the character `"."`.
 ///  - The `format` should ensure that the lexical and chronological orderings are the same
+#[cfg(feature = "chrono04")]
 pub struct TimestampSuffix {
     /// None means that we don't know the files, and a scan is necessary.
     pub(crate) suffixes: Option<VecDeque<(String, Option<usize>)>>,
@@ -99,6 +101,7 @@ pub struct TimestampSuffix {
     file_limit: FileLimit,
 }
 
+#[cfg(feature = "chrono04")]
 impl TimestampSuffix {
     /// With format `"%Y%m%dT%H%M%S"`
     pub fn default(file_limit: FileLimit) -> Self {
@@ -186,6 +189,7 @@ impl TimestampSuffix {
         }
     }
 }
+#[cfg(feature = "chrono04")]
 impl SuffixScheme for TimestampSuffix {
     fn rotate(&mut self, basepath: &Path) -> String {
         let now = Local::now().format(self.format).to_string();
@@ -261,6 +265,7 @@ impl SuffixScheme for TimestampSuffix {
 }
 
 /// How to determine if a file should be deleted, in the case of TimestampSuffix.
+#[cfg(feature = "chrono04")]
 pub enum FileLimit {
     /// Delete the oldest files if number of files is too high
     MaxFiles(usize),

--- a/src/suffix.rs
+++ b/src/suffix.rs
@@ -1,0 +1,269 @@
+use chrono::{offset::Local, DateTime, Duration};
+use std::{
+    collections::VecDeque,
+    path::{Path, PathBuf},
+};
+
+/// How to move files: How to rename, when to delete.
+pub trait SuffixScheme {
+    /// Returns new suffix to which to move current log file (does not do the move).
+    /// Deletes old log files.
+    /// Might also do other operations, like moving files in a cascading way.
+    fn rotate(&mut self, basepath: &Path) -> String;
+
+    /// Get paths of rotated log files, in order from newest to oldest.
+    /// Excludes the suffix-less log file.
+    fn log_paths(&mut self, basepath: &Path) -> Vec<PathBuf>;
+}
+
+/// Rotated log files get a number as suffix. The greater the number, the older. The oldest files
+/// are deleted.
+pub struct CountSuffix {
+    max_files: usize,
+}
+
+impl CountSuffix {
+    /// New CountSuffix
+    pub fn new(max_files: usize) -> Self {
+        Self { max_files }
+    }
+}
+
+impl SuffixScheme for CountSuffix {
+    fn rotate(&mut self, basepath: &Path) -> String {
+        /// Make sure that path(count) does not exist, by moving it to path(count+1).
+        fn cascade(basepath: &Path, count: usize, max_files: usize) {
+            let src = PathBuf::from(format!("{}.{}", basepath.display(), count));
+            if src.exists() {
+                let dest = PathBuf::from(format!("{}.{}", basepath.display(), count + 1));
+                if dest.exists() {
+                    cascade(basepath, count + 1, max_files);
+                }
+                if count >= max_files {
+                    // If the file is too old (too big count), delete it,
+                    //   (also if count == max_files, because then the .(max_files-1) file will be moved
+                    //   to .max_files)
+                    let _ = std::fs::remove_file(&src).unwrap();
+                } else {
+                    // otherwise, rename it.
+                    let _ = std::fs::rename(src, dest);
+                }
+            }
+        }
+        cascade(basepath, 1, self.max_files);
+        "1".to_string()
+    }
+    fn log_paths(&mut self, basepath: &Path) -> Vec<PathBuf> {
+        let filename_prefix = &*basepath
+            .file_name()
+            .expect("basepath.file_name()")
+            .to_string_lossy();
+        let filenames = std::fs::read_dir(basepath.parent().expect("basepath.parent()"))
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().is_file())
+            .map(|entry| entry.file_name());
+        let mut numbers = Vec::new();
+        for filename in filenames {
+            let filename = filename.to_string_lossy();
+            if !filename.starts_with(&filename_prefix) {
+                continue;
+            }
+            if let Some(dot) = filename.find('.') {
+                let suffix = &filename[(dot + 1)..];
+                if let Ok(n) = suffix.parse::<usize>() {
+                    numbers.push(n);
+                } else {
+                    continue;
+                }
+            } else {
+                // We don't consider the current (suffix-less) log file.
+            }
+        }
+        // Sort descending - the largest numbers are the oldest and thus should come first
+        numbers.sort_by(|x, y| y.cmp(x));
+        numbers
+            .iter()
+            .map(|n| PathBuf::from(format!("{}.{}", basepath.display(), n)))
+            .collect::<Vec<_>>()
+    }
+}
+
+/// Current limitations:
+///  - Neither `format` or the base filename can include the character `"."`.
+///  - The `format` should ensure that the lexical and chronological orderings are the same
+pub struct TimestampSuffix {
+    /// None means that we don't know the files, and a scan is necessary.
+    pub(crate) suffixes: Option<VecDeque<(String, Option<usize>)>>,
+    format: &'static str,
+    file_limit: FileLimit,
+}
+
+impl TimestampSuffix {
+    /// With format `"%Y%m%dT%H%M%S"`
+    pub fn default(file_limit: FileLimit) -> Self {
+        Self {
+            suffixes: None,
+            format: "%Y%m%dT%H%M%S",
+            file_limit,
+        }
+    }
+    /// Create new TimestampSuffix suffix scheme
+    pub fn with_format(format: &'static str, file_limit: FileLimit) -> Self {
+        Self {
+            suffixes: None,
+            format,
+            file_limit,
+        }
+    }
+    /// NOTE: For future use in RotationMode::Custom
+    pub fn should_rotate(&self, age: Duration) -> impl Fn(&str) -> bool {
+        let format = self.format.to_string();
+        move |suffix| {
+            let old_timestamp = (Local::now() - age).format(&format).to_string();
+            suffix < old_timestamp.as_str()
+        }
+    }
+    pub(crate) fn suffix_to_string(&self, suffix: &(String, Option<usize>)) -> String {
+        match suffix.1 {
+            Some(n) => format!("{}.{}", Local::now().format(self.format), n),
+            None => Local::now().format(self.format).to_string(),
+        }
+    }
+    pub(crate) fn suffix_to_path(
+        &self,
+        basepath: &Path,
+        suffix: &(String, Option<usize>),
+    ) -> PathBuf {
+        PathBuf::from(format!(
+            "{}.{}",
+            basepath.display(),
+            self.suffix_to_string(suffix)
+        ))
+    }
+    /// Scan files in the log directory to construct the list of files
+    fn ensure_suffix_list(&mut self, basepath: &Path) {
+        if self.suffixes.is_none() {
+            let mut suffixes = VecDeque::new();
+            let filename_prefix = &*basepath
+                .file_name()
+                .expect("basepath.file_name()")
+                .to_string_lossy();
+            let parent = basepath.parent().unwrap();
+            let filenames = std::fs::read_dir(parent)
+                .unwrap()
+                .filter_map(|entry| entry.ok())
+                .filter(|entry| entry.path().is_file())
+                .map(|entry| entry.file_name());
+            for filename in filenames {
+                let filename = filename.to_string_lossy();
+                if !filename.starts_with(&filename_prefix) {
+                    continue;
+                }
+                if let Some(first_dot) = filename.find('.') {
+                    let suffix = &filename[(first_dot + 1)..];
+                    let (timestamp_str, n) = if let Some(second_dot) = suffix.find('.') {
+                        if let Ok(n) = suffix[(second_dot + 1)..].parse::<usize>() {
+                            (&suffix[..second_dot], Some(n))
+                        } else {
+                            continue;
+                        }
+                    } else {
+                        (suffix, None)
+                    };
+                    if DateTime::parse_from_str(timestamp_str, self.format).is_ok() {
+                        suffixes.push_back((timestamp_str.to_string(), n))
+                    }
+                } else {
+                    // We don't consider the current (suffix-less) log file.
+                }
+            }
+            // Sort in Ascending order (higher value (most recent) first)
+            suffixes
+                .make_contiguous()
+                .sort_by_key(|suffix| self.suffix_to_string(suffix));
+            self.suffixes = Some(suffixes);
+        }
+    }
+}
+impl SuffixScheme for TimestampSuffix {
+    fn rotate(&mut self, basepath: &Path) -> String {
+        let now = Local::now().format(self.format).to_string();
+
+        self.ensure_suffix_list(basepath);
+
+        // For all existing suffixes that equals `now`, take the max `n`, and add one
+        let n = self
+            .suffixes
+            .as_ref()
+            .unwrap()
+            .iter()
+            .filter(|suffix| suffix.0 == now)
+            .map(|suffix| suffix.1.unwrap_or(0))
+            .max()
+            .map(|n| n + 1);
+
+        // Register the selected suffix as taken
+        self.suffixes.as_mut().unwrap().push_back((now.clone(), n));
+
+        // Remove old files
+        // Note that the oldest are the first in the list
+        let to_delete = match self.file_limit {
+            FileLimit::MaxFiles(max_files) => {
+                let n_files = self.suffixes.as_ref().unwrap().len();
+                if n_files > max_files {
+                    n_files - max_files
+                } else {
+                    0
+                }
+            }
+            FileLimit::Age(age) => {
+                let mut to_delete = 0;
+                for suffix in self.suffixes.as_ref().unwrap().iter() {
+                    let old_timestamp = (Local::now() - age).format(self.format).to_string();
+                    let delete = suffix.0 < old_timestamp;
+                    if delete {
+                        let _ = std::fs::remove_file(self.suffix_to_path(basepath, suffix));
+                        to_delete += 1;
+                    } else {
+                        // Remember that `suffixes` has the oldest entries in the front, we can `break`
+                        // once we find an entry that doesn't have to deleted
+                        break;
+                    }
+                }
+                to_delete
+            }
+        };
+
+        // Delete respective entries
+        for _ in 0..to_delete {
+            let x = self.suffixes.as_mut().unwrap().pop_front();
+            println!("DELETE FILE {:?}", x);
+        }
+
+        self.suffix_to_string(&(now, n))
+    }
+    fn log_paths(&mut self, basepath: &Path) -> Vec<PathBuf> {
+        self.ensure_suffix_list(basepath);
+        self.suffixes
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|suffix| {
+                PathBuf::from(format!(
+                    "{}.{}",
+                    basepath.display(),
+                    self.suffix_to_string(suffix)
+                ))
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+/// How to determine if a file should be deleted, in the case of TimestampSuffix.
+pub enum FileLimit {
+    /// Delete the oldest files if number of files is too high
+    MaxFiles(usize),
+    /// Delete files that have too old timestamp
+    Age(Duration),
+}

--- a/src/suffix.rs
+++ b/src/suffix.rs
@@ -1,21 +1,47 @@
-use chrono::NaiveDateTime;
 #[cfg(feature = "chrono04")]
-use chrono::{offset::Local, Duration};
+use chrono::{offset::Local, Duration, NaiveDateTime};
 use std::{
-    collections::VecDeque,
+    cmp::Ordering,
     path::{Path, PathBuf},
 };
 
+/// Representation of a suffix
+/// `Ord + PartialOrd`: sort by age of the suffix. Most recent first (smallest).
+pub trait Representation: Ord + ToString + Eq + Clone + std::fmt::Debug {
+    /// Create path
+    fn to_path(&self, basepath: &Path) -> PathBuf {
+        PathBuf::from(format!("{}.{}", basepath.display(), self.to_string()))
+    }
+}
+
 /// How to move files: How to rename, when to delete.
 pub trait SuffixScheme {
-    /// Returns new suffix to which to move current log file (does not do the move).
-    /// Deletes old log files.
-    /// Might also do other operations, like moving files in a cascading way.
-    fn rotate(&mut self, basepath: &Path) -> String;
+    /// The representation of suffixes that this suffix scheme uses.
+    /// E.g. if the suffix is a number, you can use `usize`.
+    type Repr: Representation;
 
-    /// Get paths of rotated log files, in order from newest to oldest.
-    /// Excludes the suffix-less log file.
-    fn log_paths(&mut self, basepath: &Path) -> Vec<PathBuf>;
+    /// The file at `suffix` needs to be rotated.
+    /// Returns the target file path.
+    /// The file will be moved outside this function.
+    /// If the target path already exists, rotate_file is called again with `path` set to the
+    /// target path.  Thus it cascades files by default, and if this is not desired, it's up to
+    /// `rotate_file` to return a path that does not already exist.
+    ///
+    /// `prev_suffix` is provided just in case it's useful (not always)
+    fn rotate_file(
+        &mut self,
+        basepath: &Path,
+        newest_suffix: Option<&Self::Repr>,
+        suffix: &Option<Self::Repr>,
+    ) -> Self::Repr;
+
+    /// Parse suffix from string.
+    fn parse(&self, suffix: &str) -> Option<Self::Repr>;
+
+    /// Whether either the suffix or the chronological file number indicates that the file is old
+    /// and should be deleted, depending of course on the file limit.
+    /// `file_number` starts at 0.
+    fn too_old(&self, suffix: &Self::Repr, file_number: usize) -> bool;
 }
 
 /// Rotated log files get a number as suffix. The greater the number, the older. The oldest files
@@ -31,63 +57,23 @@ impl CountSuffix {
     }
 }
 
+impl Representation for usize {}
 impl SuffixScheme for CountSuffix {
-    fn rotate(&mut self, basepath: &Path) -> String {
-        /// Make sure that path(count) does not exist, by moving it to path(count+1).
-        fn cascade(basepath: &Path, count: usize, max_files: usize) {
-            let src = PathBuf::from(format!("{}.{}", basepath.display(), count));
-            if src.exists() {
-                let dest = PathBuf::from(format!("{}.{}", basepath.display(), count + 1));
-                if dest.exists() {
-                    cascade(basepath, count + 1, max_files);
-                }
-                if count >= max_files {
-                    // If the file is too old (too big count), delete it,
-                    //   (also if count == max_files, because then the .(max_files-1) file will be moved
-                    //   to .max_files)
-                    let _ = std::fs::remove_file(&src).unwrap();
-                } else {
-                    // otherwise, rename it.
-                    let _ = std::fs::rename(src, dest);
-                }
-            }
+    type Repr = usize;
+    fn rotate_file(&mut self,
+        _basepath: &Path,
+        _: Option<&usize>,
+        suffix: &Option<usize>) -> usize {
+        match suffix {
+            Some(suffix) => suffix + 1,
+            None => 1,
         }
-        cascade(basepath, 1, self.max_files);
-        "1".to_string()
     }
-    fn log_paths(&mut self, basepath: &Path) -> Vec<PathBuf> {
-        let filename_prefix = &*basepath
-            .file_name()
-            .expect("basepath.file_name()")
-            .to_string_lossy();
-        let filenames = std::fs::read_dir(basepath.parent().expect("basepath.parent()"))
-            .unwrap()
-            .filter_map(|entry| entry.ok())
-            .filter(|entry| entry.path().is_file())
-            .map(|entry| entry.file_name());
-        let mut numbers = Vec::new();
-        for filename in filenames {
-            let filename = filename.to_string_lossy();
-            if !filename.starts_with(&filename_prefix) {
-                continue;
-            }
-            if let Some(dot) = filename.find('.') {
-                let suffix = &filename[(dot + 1)..];
-                if let Ok(n) = suffix.parse::<usize>() {
-                    numbers.push(n);
-                } else {
-                    continue;
-                }
-            } else {
-                // We don't consider the current (suffix-less) log file.
-            }
-        }
-        // Sort descending - the largest numbers are the oldest and thus should come first
-        numbers.sort_by(|x, y| y.cmp(x));
-        numbers
-            .iter()
-            .map(|n| PathBuf::from(format!("{}.{}", basepath.display(), n)))
-            .collect::<Vec<_>>()
+    fn parse(&self, suffix: &str) -> Option<usize> {
+        suffix.parse::<usize>().ok()
+    }
+    fn too_old(&self, _suffix: &usize, file_number: usize) -> bool {
+        file_number >= self.max_files
     }
 }
 
@@ -95,30 +81,23 @@ impl SuffixScheme for CountSuffix {
 ///  - Neither `format` or the base filename can include the character `"."`.
 ///  - The `format` should ensure that the lexical and chronological orderings are the same
 #[cfg(feature = "chrono04")]
-pub struct TimestampSuffix {
-    /// None means that we don't know the files, and a scan is necessary.
-    pub(crate) suffixes: Option<VecDeque<(String, Option<usize>)>>,
+pub struct TimestampSuffixScheme {
     format: &'static str,
     file_limit: FileLimit,
 }
 
 #[cfg(feature = "chrono04")]
-impl TimestampSuffix {
+impl TimestampSuffixScheme {
     /// With format `"%Y%m%dT%H%M%S"`
     pub fn default(file_limit: FileLimit) -> Self {
         Self {
-            suffixes: None,
             format: "%Y%m%dT%H%M%S",
             file_limit,
         }
     }
-    /// Create new TimestampSuffix suffix scheme
+    /// Create new TimestampSuffixScheme suffix scheme
     pub fn with_format(format: &'static str, file_limit: FileLimit) -> Self {
-        Self {
-            suffixes: None,
-            format,
-            file_limit,
-        }
+        Self { format, file_limit }
     }
     /// NOTE: For future use in RotationMode::Custom
     pub fn should_rotate(&self, age: Duration) -> impl Fn(&str) -> bool {
@@ -128,148 +107,130 @@ impl TimestampSuffix {
             suffix < old_timestamp.as_str()
         }
     }
-    pub(crate) fn suffix_to_string(&self, suffix: &(String, Option<usize>)) -> String {
-        match suffix.1 {
-            Some(n) => format!("{}.{}", suffix.0, n),
-            None => suffix.0.clone(),
-        }
-    }
-    pub(crate) fn suffix_to_path(
-        &self,
-        basepath: &Path,
-        suffix: &(String, Option<usize>),
-    ) -> PathBuf {
-        PathBuf::from(format!(
-            "{}.{}",
-            basepath.display(),
-            self.suffix_to_string(suffix)
-        ))
-    }
-    /// Scan files in the log directory to construct the list of files
-    fn ensure_suffix_list(&mut self, basepath: &Path) {
-        if self.suffixes.is_none() {
-            let mut suffixes = VecDeque::new();
-            let filename_prefix = &*basepath
-                .file_name()
-                .expect("basepath.file_name()")
-                .to_string_lossy();
-            let parent = basepath.parent().unwrap();
-            let filenames = std::fs::read_dir(parent)
-                .unwrap()
-                .filter_map(|entry| entry.ok())
-                .filter(|entry| entry.path().is_file())
-                .map(|entry| entry.file_name());
-            for filename in filenames {
-                let filename = filename.to_string_lossy();
-                if !filename.starts_with(&filename_prefix) {
-                    continue;
-                }
-                // Find the up to two `.` in the filename
-                if let Some(first_dot) = filename.find('.') {
-                    let suffix = &filename[(first_dot + 1)..];
-                    let (timestamp_str, n) = if let Some(second_dot) = suffix.find('.') {
-                        if let Ok(n) = suffix[(second_dot + 1)..].parse::<usize>() {
-                            (&suffix[..second_dot], Some(n))
-                        } else {
-                            continue;
-                        }
-                    } else {
-                        (suffix, None)
-                    };
-                    if NaiveDateTime::parse_from_str(timestamp_str, self.format).is_ok() {
-                        suffixes.push_back((timestamp_str.to_string(), n))
-                    }
-                } else {
-                    // We don't consider the current (suffix-less) log file.
-                }
-            }
-            // Sort in Ascending order (higher value (most recent) first)
-            suffixes
-                .make_contiguous()
-                .sort_by_key(|suffix| self.suffix_to_string(suffix));
-            self.suffixes = Some(suffixes);
+}
+
+/// Structured representation of the suffixes of TimestampSuffixScheme.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimestampSuffix {
+    timestamp: String,
+    number: Option<usize>,
+}
+impl Representation for TimestampSuffix {}
+impl Ord for TimestampSuffix {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Most recent = smallest (opposite as the timestamp Ord)
+        // Smallest = most recent. Thus, biggest timestamp first. And then biggest number
+        match other.timestamp.cmp(&self.timestamp) {
+            Ordering::Equal => other.number.cmp(&self.number),
+            unequal => unequal,
         }
     }
 }
+impl PartialOrd for TimestampSuffix {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::fmt::Display for TimestampSuffix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self.number {
+            Some(n) => write!(f, "{}.{}", self.timestamp, n),
+            None => write!(f, "{}", self.timestamp),
+        }
+    }
+}
+
 #[cfg(feature = "chrono04")]
-impl SuffixScheme for TimestampSuffix {
-    fn rotate(&mut self, basepath: &Path) -> String {
-        let now = Local::now().format(self.format).to_string();
+impl SuffixScheme for TimestampSuffixScheme {
+    type Repr = TimestampSuffix;
 
-        self.ensure_suffix_list(basepath);
+    fn rotate_file(
+        &mut self,
+        _basepath: &Path,
+        newest_suffix: Option<&TimestampSuffix>,
+        suffix: &Option<TimestampSuffix>,
+    ) -> TimestampSuffix {
+        if suffix.is_none() {
+            let now = Local::now().format(self.format).to_string();
 
-        // For all existing suffixes that equals `now`, take the max `n`, and add one
-        let n = self
-            .suffixes
-            .as_ref()
-            .unwrap()
-            .iter()
-            .filter(|suffix| suffix.0 == now)
-            .map(|suffix| suffix.1.unwrap_or(0))
-            .max()
-            .map(|n| n + 1);
-
-        // Register the selected suffix as taken
-        self.suffixes.as_mut().unwrap().push_back((now.clone(), n));
-
-        // Remove old files
-        // Note that the oldest are the first in the list
-        let to_delete = match self.file_limit {
-            FileLimit::MaxFiles(max_files) => {
-                let n_files = self.suffixes.as_ref().unwrap().len();
-                if n_files > max_files {
-                    n_files - max_files
+            let number = if let Some(newest_suffix) = newest_suffix {
+                if newest_suffix.timestamp == now {
+                    Some(newest_suffix.number.unwrap_or(0) + 1)
                 } else {
-                    0
+                    None
                 }
+            } else {
+                None
+            };
+            TimestampSuffix {
+                timestamp: now,
+                number
             }
-            FileLimit::Age(age) => {
-                let mut to_delete = 0;
-                for suffix in self.suffixes.as_ref().unwrap().iter() {
-                    let old_timestamp = (Local::now() - age).format(self.format).to_string();
-                    let delete = suffix.0 < old_timestamp;
-                    if delete {
-                        let _ = std::fs::remove_file(self.suffix_to_path(basepath, suffix));
-                        to_delete += 1;
-                    } else {
-                        // Remember that `suffixes` has the oldest entries in the front, we can `break`
-                        // once we find an entry that doesn't have to deleted
-                        break;
-                    }
-                }
-                to_delete
-            }
-        };
-
-        // Delete respective entries
-        for _ in 0..to_delete {
-            self.suffixes.as_mut().unwrap().pop_front();
+        } else {
+            // This rotation scheme dictates that only the main log file should ever be renamed.
+            // TODO: do something else than panic
+            panic!("programmer error in TimestampSuffixScheme::rotate_file")
         }
-
-        self.suffix_to_string(&(now, n))
     }
-    fn log_paths(&mut self, basepath: &Path) -> Vec<PathBuf> {
-        self.ensure_suffix_list(basepath);
-        self.suffixes
-            .as_ref()
-            .unwrap()
-            .iter()
-            .map(|suffix| {
-                PathBuf::from(format!(
-                    "{}.{}",
-                    basepath.display(),
-                    self.suffix_to_string(suffix)
-                ))
+    fn parse(&self, suffix: &str) -> Option<Self::Repr> {
+        let (timestamp_str, n) = if let Some(dot) = suffix.find('.') {
+            if let Ok(n) = suffix[(dot + 1)..].parse::<usize>() {
+                (&suffix[..dot], Some(n))
+            } else {
+                return None;
+            }
+        } else {
+            (suffix, None)
+        };
+        NaiveDateTime::parse_from_str(timestamp_str, self.format)
+            .map(|_| TimestampSuffix {
+                timestamp: timestamp_str.to_string(),
+                number: n,
             })
-            .collect::<Vec<_>>()
+            .ok()
+    }
+    fn too_old(&self, suffix: &TimestampSuffix, file_number: usize) -> bool {
+        match self.file_limit {
+            FileLimit::MaxFiles(max_files) => file_number >= max_files,
+            FileLimit::Age(age) => {
+                let old_timestamp = (Local::now() - age).format(self.format).to_string();
+                suffix.timestamp < old_timestamp
+            }
+        }
     }
 }
 
-/// How to determine if a file should be deleted, in the case of TimestampSuffix.
+/// How to determine if a file should be deleted, in the case of TimestampSuffixScheme.
 #[cfg(feature = "chrono04")]
 pub enum FileLimit {
     /// Delete the oldest files if number of files is too high
     MaxFiles(usize),
     /// Delete files that have too old timestamp
     Age(Duration),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn timestamp_ordering() {
+        assert!(
+            TimestampSuffix {
+                timestamp: "2021".to_string(),
+                number: None
+            } < TimestampSuffix {
+                timestamp: "2020".to_string(),
+                number: None
+            }
+        );
+        assert!(
+            TimestampSuffix {
+                timestamp: "2021".to_string(),
+                number: Some(1)
+            } < TimestampSuffix {
+                timestamp: "2021".to_string(),
+                number: None
+            }
+        );
+    }
 }

--- a/src/suffix.rs
+++ b/src/suffix.rs
@@ -1,5 +1,6 @@
+use chrono::NaiveDateTime;
 #[cfg(feature = "chrono04")]
-use chrono::{offset::Local, DateTime, Duration};
+use chrono::{offset::Local, Duration};
 use std::{
     collections::VecDeque,
     path::{Path, PathBuf},
@@ -129,8 +130,8 @@ impl TimestampSuffix {
     }
     pub(crate) fn suffix_to_string(&self, suffix: &(String, Option<usize>)) -> String {
         match suffix.1 {
-            Some(n) => format!("{}.{}", Local::now().format(self.format), n),
-            None => Local::now().format(self.format).to_string(),
+            Some(n) => format!("{}.{}", suffix.0, n),
+            None => suffix.0.clone(),
         }
     }
     pub(crate) fn suffix_to_path(
@@ -163,6 +164,7 @@ impl TimestampSuffix {
                 if !filename.starts_with(&filename_prefix) {
                     continue;
                 }
+                // Find the up to two `.` in the filename
                 if let Some(first_dot) = filename.find('.') {
                     let suffix = &filename[(first_dot + 1)..];
                     let (timestamp_str, n) = if let Some(second_dot) = suffix.find('.') {
@@ -174,7 +176,7 @@ impl TimestampSuffix {
                     } else {
                         (suffix, None)
                     };
-                    if DateTime::parse_from_str(timestamp_str, self.format).is_ok() {
+                    if NaiveDateTime::parse_from_str(timestamp_str, self.format).is_ok() {
                         suffixes.push_back((timestamp_str.to_string(), n))
                     }
                 } else {
@@ -241,8 +243,7 @@ impl SuffixScheme for TimestampSuffix {
 
         // Delete respective entries
         for _ in 0..to_delete {
-            let x = self.suffixes.as_mut().unwrap().pop_front();
-            println!("DELETE FILE {:?}", x);
+            self.suffixes.as_mut().unwrap().pop_front();
         }
 
         self.suffix_to_string(&(now, n))


### PR DESCRIPTION
Builds on #7. So this branch includes the "extensible suffix behaviour" feature, and adds compression.
Compression makes the code somewhat more complex. We have to keep track not only of suffixes, but whether or not they have a `.gz`.
For example, If we want to rotate a file `log.1`, and `log.2.gz` exists, we have to rotate `log.2.gz` to `log.3.gz` (recursively), and then we can move `log.1` to `log.2`, after which compression is triggered which again creates `log.2.gz`.
`SuffixScheme` however is blissfully unaware of compression and any `.gz` suffix.

I decided for now to keep `self.suffixes` (the alternative is to just use `fs::read_dir` repeatedly instead of keeping track of suffixes in a `BTreeSet`, and the difference is: less performance, more robustness). I wonder if code would be less complex if we went for more file ops.