### PR TITLE
Remove time dependency to fix CVE-2020-26235

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords= ["log", "rotate", "logrotate"]
 license = "MIT"
 
 [dependencies]
-chrono = {version = "0.4.20", optional = true }
+chrono = { version = "0.4.20", optional = true, default-features = false, features = ["clock"] }
 flate2 = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
[CVE-2020-26235](https://github.com/advisories/GHSA-wcg3-cvx6-7396) is caused by the time dependency that's included in chrono. Currently, the chrono devs refactored away the dependency on time into the feature `oldtime`, which is enabled by default (reference: https://github.com/chronotope/chrono/issues/602).

This PR explicitly excludes the `oldtime` feature, so that GitHub's dependabot stops bugging users of this crate (like me 😅).