### PR TITLE
Add default features for time and compression

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,5 +26,11 @@ jobs:
           - os: windows-latest  
     steps:
     - uses: actions/checkout@v3
-    - name: Test
+    - name: Test (default features)
       run: cargo test
+    - name: Test (no default features)
+      run: cargo test --tests --no-default-features
+    - name: Test (compression feature only)
+      run: cargo test --tests --no-default-features --features compression
+    - name: Test (time feature only)
+      run: cargo test --tests --no-default-features --features time

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,14 @@ repository = "https://github.com/kstrafe/file-rotate"
 keywords= ["log", "rotate", "logrotate"]
 license = "MIT"
 
+[features]
+default = ["time", "compression"]
+time = ["dep:chrono"]
+compression = ["dep:flate2"]
+
 [dependencies]
-chrono = { version = "0.4.20", default-features = false, features = ["clock"] }
-flate2 = "1.0"
+chrono = { version = "0.4.20", default-features = false, features = ["clock"], optional = true }
+flate2 = { version = "1.0", optional = true }
 
 [dev-dependencies]
 filetime = "0.2"

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,10 +1,12 @@
 //! Compression - configuration and implementation
+#[cfg(feature = "compression")]
 use flate2::write::GzEncoder;
+#[cfg(feature = "compression")]
 use std::{
     fs::{self, File, OpenOptions},
-    io,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
+use std::{io, path::Path};
 
 /// Compression mode - when to compress files.
 #[derive(Debug, Clone)]
@@ -12,26 +14,31 @@ pub enum Compression {
     /// No compression
     None,
     /// Look for files to compress when rotating.
-    /// First argument: How many files to keep uncompressed (excluding the original file)
+    /// First argument: How many files to keep uncompressed (excluding the original file).
+    /// If `compression` feature is not enabled, this is a no-op.
     OnRotate(usize),
 }
 
+/// Compress file at path. If `compression` feature is not enabled, this is a no-op.
 pub(crate) fn compress(path: &Path) -> io::Result<()> {
-    let dest_path = PathBuf::from(format!("{}.gz", path.display()));
+    #[cfg(feature = "compression")]
+    {
+        let dest_path = PathBuf::from(format!("{}.gz", path.display()));
 
-    let mut src_file = File::open(path)?;
-    let dest_file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .append(false)
-        .open(&dest_path)?;
+        let mut src_file = File::open(path)?;
+        let dest_file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .append(false)
+            .open(&dest_path)?;
 
-    assert!(path.exists());
-    assert!(dest_path.exists());
-    let mut encoder = GzEncoder::new(dest_file, flate2::Compression::default());
-    io::copy(&mut src_file, &mut encoder)?;
+        assert!(path.exists());
+        assert!(dest_path.exists());
+        let mut encoder = GzEncoder::new(dest_file, flate2::Compression::default());
+        io::copy(&mut src_file, &mut encoder)?;
 
-    fs::remove_file(path)?;
+        fs::remove_file(path)?;
+    }
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,8 @@
     unused_qualifications
 )]
 
+
+#[cfg(feature = "time")]
 use chrono::prelude::*;
 use compression::*;
 use std::io::{BufRead, BufReader};
@@ -328,6 +330,7 @@ pub enum ContentLimit {
     /// Cut the log file at line breaks.
     Lines(usize),
     /// Cut the log at time interval.
+    /// If the `time` feature is not enabled no file rotation will be performed, same as in [`ContentLimit::None`].
     Time(TimeFrequency),
     /// Cut the log file after surpassing size in bytes (but having written a complete buffer from a write call.)
     BytesSurpassed(usize),
@@ -377,6 +380,7 @@ impl<Repr: Representation> PartialOrd for SuffixInfo<Repr> {
 pub struct FileRotate<S: SuffixScheme> {
     basepath: PathBuf,
     file: Option<File>,
+    #[cfg(feature = "time")]
     modified: Option<DateTime<Local>>,
     content_limit: ContentLimit,
     count: usize,
@@ -426,6 +430,7 @@ impl<S: SuffixScheme> FileRotate<S> {
 
         let mut s = Self {
             file: None,
+            #[cfg(feature = "time")]
             modified: None,
             basepath,
             content_limit,
@@ -466,7 +471,10 @@ impl<S: SuffixScheme> FileRotate<S> {
                             self.count = BufReader::new(file).lines().count();
                         }
                         ContentLimit::Time(_) => {
-                            self.modified = mtime(file);
+                            #[cfg(feature = "time")]
+                            {
+                                self.modified = mtime(file);
+                            }
                         }
                         ContentLimit::None => {}
                     }
@@ -596,6 +604,7 @@ impl<S: SuffixScheme> FileRotate<S> {
         }
 
         // Compression
+        #[cfg(feature = "compression")]
         if let Compression::OnRotate(max_file_n) = self.compression {
             let n = (self.suffixes.len() as i32 - max_file_n as i32).max(0) as usize;
             // The oldest N files should be compressed
@@ -642,49 +651,58 @@ impl<S: SuffixScheme> Write for FileRotate<S> {
                 }
             }
             ContentLimit::Time(time) => {
-                let local: DateTime<Local> = now();
+                #[cfg(feature = "time")]
+                {
+                    let local: DateTime<Local> = now();
 
-                if let Some(modified) = self.modified {
-                    match time {
-                        TimeFrequency::Hourly => {
-                            if local.hour() != modified.hour()
-                                || local.day() != modified.day()
-                                || local.month() != modified.month()
-                                || local.year() != modified.year()
-                            {
-                                self.rotate()?;
+                    if let Some(modified) = self.modified {
+                        match time {
+                            TimeFrequency::Hourly => {
+                                if local.hour() != modified.hour()
+                                    || local.day() != modified.day()
+                                    || local.month() != modified.month()
+                                    || local.year() != modified.year()
+                                {
+                                    self.rotate()?;
+                                }
                             }
-                        }
-                        TimeFrequency::Daily => {
-                            if local.date() > modified.date() {
-                                self.rotate()?;
+                            TimeFrequency::Daily => {
+                                if local.date() > modified.date() {
+                                    self.rotate()?;
+                                }
                             }
-                        }
-                        TimeFrequency::Weekly => {
-                            if local.iso_week().week() != modified.iso_week().week()
-                                || local.year() > modified.year()
-                            {
-                                self.rotate()?;
+                            TimeFrequency::Weekly => {
+                                if local.iso_week().week() != modified.iso_week().week()
+                                    || local.year() > modified.year()
+                                {
+                                    self.rotate()?;
+                                }
                             }
-                        }
-                        TimeFrequency::Monthly => {
-                            if local.month() != modified.month() || local.year() != modified.year()
-                            {
-                                self.rotate()?;
+                            TimeFrequency::Monthly => {
+                                if local.month() != modified.month() || local.year() != modified.year()
+                                {
+                                    self.rotate()?;
+                                }
                             }
-                        }
-                        TimeFrequency::Yearly => {
-                            if local.year() > modified.year() {
-                                self.rotate()?;
+                            TimeFrequency::Yearly => {
+                                if local.year() > modified.year() {
+                                    self.rotate()?;
+                                }
                             }
                         }
                     }
+
+                    if let Some(ref mut file) = self.file {
+                        file.write_all(buf)?;
+                        self.modified = Some(local);
+                    }
                 }
 
-                if let Some(ref mut file) = self.file {
-                    file.write_all(buf)?;
-
-                    self.modified = Some(local);
+                #[cfg(not(feature = "time"))]
+                {
+                    if let Some(ref mut file) = self.file {
+                        file.write_all(buf)?;
+                    }
                 }
             }
             ContentLimit::Lines(lines) => {
@@ -731,6 +749,7 @@ impl<S: SuffixScheme> Write for FileRotate<S> {
 
 /// Get modification time, in non test case.
 #[cfg(not(test))]
+#[cfg(feature = "time")]
 fn mtime(file: &File) -> Option<DateTime<Local>> {
     if let Ok(time) = file.metadata().and_then(|metadata| metadata.modified()) {
         return Some(time.into());
@@ -741,18 +760,21 @@ fn mtime(file: &File) -> Option<DateTime<Local>> {
 
 /// Get modification time, in test case.
 #[cfg(test)]
+#[cfg(feature = "time")]
 fn mtime(_: &File) -> Option<DateTime<Local>> {
     Some(now())
 }
 
 /// Get system time, in non test case.
 #[cfg(not(test))]
+#[cfg(feature = "time")]
 fn now() -> DateTime<Local> {
     Local::now()
 }
 
 /// Get mocked system time, in test case.
 #[cfg(test)]
+#[cfg(feature = "time")]
 pub mod mock_time {
     use super::*;
     use std::cell::RefCell;
@@ -773,4 +795,5 @@ pub mod mock_time {
 }
 
 #[cfg(test)]
+#[cfg(feature = "time")]
 pub use mock_time::now;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,9 +291,7 @@
     unused_qualifications
 )]
 
-#[cfg(feature = "time")]
 use chrono::prelude::*;
-#[cfg(feature = "compression")]
 use compression::*;
 use std::io::{BufRead, BufReader};
 use std::{
@@ -308,7 +306,6 @@ use suffix::*;
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 
-#[cfg(feature = "compression")]
 pub mod compression;
 pub mod suffix;
 #[cfg(test)]
@@ -318,7 +315,6 @@ mod tests;
 
 /// At which frequency to rotate the file.
 #[derive(Clone, Copy, Debug)]
-#[cfg(feature = "time")]
 pub enum TimeFrequency {
     /// Rotate every hour.
     Hourly,
@@ -340,7 +336,6 @@ pub enum ContentLimit {
     /// Cut the log file at line breaks.
     Lines(usize),
     /// Cut the log at time interval.
-    #[cfg(feature = "time")]
     Time(TimeFrequency),
     /// Cut the log file after surpassing size in bytes (but having written a complete buffer from a write call.)
     BytesSurpassed(usize),
@@ -390,14 +385,15 @@ impl<Repr: Representation> PartialOrd for SuffixInfo<Repr> {
 pub struct FileRotate<S: SuffixScheme> {
     basepath: PathBuf,
     file: Option<File>,
-    #[cfg(feature = "time")] modified: Option<DateTime<Local>>,
+    modified: Option<DateTime<Local>>,
     content_limit: ContentLimit,
     count: usize,
-    #[cfg(feature = "compression")] compression: Compression,
+    compression: Compression,
     suffix_scheme: S,
     /// The bool is whether or not there's a .gz suffix to the filename
     suffixes: BTreeSet<SuffixInfo<S::Repr>>,
-    #[cfg(unix)] mode: Option<u32>,
+    #[cfg(unix)]
+    mode: Option<u32>,
 }
 
 impl<S: SuffixScheme> FileRotate<S> {
@@ -415,7 +411,7 @@ impl<S: SuffixScheme> FileRotate<S> {
         path: P,
         suffix_scheme: S,
         content_limit: ContentLimit,
-        #[cfg(feature = "compression")] compression: Compression,
+        compression: Compression,
         #[cfg(unix)] mode: Option<u32>,
     ) -> Self {
         match content_limit {
@@ -425,7 +421,7 @@ impl<S: SuffixScheme> FileRotate<S> {
             ContentLimit::Lines(lines) => {
                 assert!(lines > 0);
             }
-            #[cfg(feature = "time")] ContentLimit::Time(_) => {}
+            ContentLimit::Time(_) => {}
             ContentLimit::BytesSurpassed(bytes) => {
                 assert!(bytes > 0);
             }
@@ -437,14 +433,15 @@ impl<S: SuffixScheme> FileRotate<S> {
 
         let mut s = Self {
             file: None,
-            #[cfg(feature = "time")] modified: None,
+            modified: None,
             basepath,
             content_limit,
             count: 0,
-            #[cfg(feature = "compression")] compression,
+            compression,
             suffixes: BTreeSet::new(),
             suffix_scheme,
-            #[cfg(unix)] mode,
+            #[cfg(unix)]
+            mode,
         };
         s.ensure_log_directory_exists();
         s.scan_suffixes();
@@ -476,7 +473,6 @@ impl<S: SuffixScheme> FileRotate<S> {
                         ContentLimit::Lines(_) => {
                             self.count = BufReader::new(file).lines().count();
                         }
-                        #[cfg(feature = "time")]
                         ContentLimit::Time(_) => {
                             self.modified = mtime(file);
                         }
@@ -611,7 +607,6 @@ impl<S: SuffixScheme> FileRotate<S> {
         }
 
         // Compression
-        #[cfg(feature = "compression")]
         if let Compression::OnRotate(max_file_n) = self.compression {
             let n = (self.suffixes.len() as i32 - max_file_n as i32).max(0) as usize;
             // The oldest N files should be compressed
@@ -657,7 +652,6 @@ impl<S: SuffixScheme> Write for FileRotate<S> {
                     file.write_all(buf)?;
                 }
             }
-            #[cfg(feature = "time")]
             ContentLimit::Time(time) => {
                 let local: DateTime<Local> = now();
 
@@ -747,7 +741,7 @@ impl<S: SuffixScheme> Write for FileRotate<S> {
 }
 
 /// Get modification time, in non test case.
-#[cfg(all(not(test), feature = "time"))]
+#[cfg(not(test))]
 fn mtime(file: &File) -> Option<DateTime<Local>> {
     if let Ok(time) = file.metadata().and_then(|metadata| metadata.modified()) {
         return Some(time.into());
@@ -757,19 +751,19 @@ fn mtime(file: &File) -> Option<DateTime<Local>> {
 }
 
 /// Get modification time, in test case.
-#[cfg(all(test, feature = "time"))]
+#[cfg(test)]
 fn mtime(_: &File) -> Option<DateTime<Local>> {
     Some(now())
 }
 
 /// Get system time, in non test case.
-#[cfg(all(not(test), feature = "time"))]
+#[cfg(not(test))]
 fn now() -> DateTime<Local> {
     Local::now()
 }
 
 /// Get mocked system time, in test case.
-#[cfg(all(test, feature = "time"))]
+#[cfg(test)]
 pub mod mock_time {
     use super::*;
     use std::cell::RefCell;
@@ -787,5 +781,5 @@ pub mod mock_time {
     }
 }
 
-#[cfg(all(test, feature = "time"))]
+#[cfg(test)]
 pub use mock_time::now;

--- a/src/suffix.rs
+++ b/src/suffix.rs
@@ -3,11 +3,14 @@
 //! This behaviour is fully extensible through the [SuffixScheme] trait, and two behaviours are
 //! provided: [AppendCount] and [AppendTimestamp]
 //!
+#[cfg(feature = "time")]
 use super::now;
 use crate::SuffixInfo;
+#[cfg(feature = "time")]
 use chrono::{format::ParseErrorKind, offset::Local, Duration, NaiveDateTime};
+#[cfg(feature = "time")]
+use std::cmp::Ordering;
 use std::{
-    cmp::Ordering,
     collections::BTreeSet,
     io,
     path::{Path, PathBuf},
@@ -141,6 +144,7 @@ impl SuffixScheme for AppendCount {
 }
 
 /// Add timestamp from:
+#[cfg(feature = "time")]
 pub enum DateFrom {
     /// Date yesterday, to represent the timestamps within the log file.
     DateYesterday,
@@ -156,6 +160,7 @@ pub enum DateFrom {
 /// Current limitations:
 ///  - Neither `format` nor the base filename can include the character `"."`.
 ///  - The `format` should ensure that the lexical and chronological orderings are the same
+#[cfg(feature = "time")]
 pub struct AppendTimestamp {
     /// The format of the timestamp suffix
     pub format: &'static str,
@@ -165,6 +170,7 @@ pub struct AppendTimestamp {
     pub date_from: DateFrom,
 }
 
+#[cfg(feature = "time")]
 impl AppendTimestamp {
     /// With format `"%Y%m%dT%H%M%S"`
     pub fn default(file_limit: FileLimit) -> Self {
@@ -186,13 +192,16 @@ impl AppendTimestamp {
 
 /// Structured representation of the suffixes of AppendTimestamp.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(feature = "time")]
 pub struct TimestampSuffix {
     /// The timestamp
     pub timestamp: String,
     /// Optional number suffix if two timestamp suffixes are the same
     pub number: Option<usize>,
 }
+#[cfg(feature = "time")]
 impl Representation for TimestampSuffix {}
+#[cfg(feature = "time")]
 impl Ord for TimestampSuffix {
     fn cmp(&self, other: &Self) -> Ordering {
         // Most recent = smallest (opposite as the timestamp Ord)
@@ -203,11 +212,13 @@ impl Ord for TimestampSuffix {
         }
     }
 }
+#[cfg(feature = "time")]
 impl PartialOrd for TimestampSuffix {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
+#[cfg(feature = "time")]
 impl std::fmt::Display for TimestampSuffix {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self.number {
@@ -217,6 +228,7 @@ impl std::fmt::Display for TimestampSuffix {
     }
 }
 
+#[cfg(feature = "time")]
 impl SuffixScheme for AppendTimestamp {
     type Repr = TimestampSuffix;
 
@@ -304,12 +316,13 @@ pub enum FileLimit {
     /// Delete the oldest files if number of files is too high
     MaxFiles(usize),
     /// Delete files whose age exceeds the `Duration` - age is determined by the suffix of the file
+    #[cfg(feature = "time")]
     Age(Duration),
     /// Never delete files
     Unlimited,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "time"))]
 mod test {
     use super::*;
     use std::fs::File;

--- a/src/suffix.rs
+++ b/src/suffix.rs
@@ -3,14 +3,11 @@
 //! This behaviour is fully extensible through the [SuffixScheme] trait, and two behaviours are
 //! provided: [AppendCount] and [AppendTimestamp]
 //!
-#[cfg(feature = "time")]
 use super::now;
 use crate::SuffixInfo;
-#[cfg(feature = "time")]
 use chrono::{format::ParseErrorKind, offset::Local, Duration, NaiveDateTime};
-#[cfg(feature = "time")]
-use std::cmp::Ordering;
 use std::{
+    cmp::Ordering,
     collections::BTreeSet,
     io,
     path::{Path, PathBuf},
@@ -144,7 +141,6 @@ impl SuffixScheme for AppendCount {
 }
 
 /// Add timestamp from:
-#[cfg(feature = "time")]
 pub enum DateFrom {
     /// Date yesterday, to represent the timestamps within the log file.
     DateYesterday,
@@ -160,7 +156,6 @@ pub enum DateFrom {
 /// Current limitations:
 ///  - Neither `format` nor the base filename can include the character `"."`.
 ///  - The `format` should ensure that the lexical and chronological orderings are the same
-#[cfg(feature = "time")]
 pub struct AppendTimestamp {
     /// The format of the timestamp suffix
     pub format: &'static str,
@@ -170,7 +165,6 @@ pub struct AppendTimestamp {
     pub date_from: DateFrom,
 }
 
-#[cfg(feature = "time")]
 impl AppendTimestamp {
     /// With format `"%Y%m%dT%H%M%S"`
     pub fn default(file_limit: FileLimit) -> Self {
@@ -192,16 +186,13 @@ impl AppendTimestamp {
 
 /// Structured representation of the suffixes of AppendTimestamp.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg(feature = "time")]
 pub struct TimestampSuffix {
     /// The timestamp
     pub timestamp: String,
     /// Optional number suffix if two timestamp suffixes are the same
     pub number: Option<usize>,
 }
-#[cfg(feature = "time")]
 impl Representation for TimestampSuffix {}
-#[cfg(feature = "time")]
 impl Ord for TimestampSuffix {
     fn cmp(&self, other: &Self) -> Ordering {
         // Most recent = smallest (opposite as the timestamp Ord)
@@ -212,13 +203,11 @@ impl Ord for TimestampSuffix {
         }
     }
 }
-#[cfg(feature = "time")]
 impl PartialOrd for TimestampSuffix {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
-#[cfg(feature = "time")]
 impl std::fmt::Display for TimestampSuffix {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self.number {
@@ -228,7 +217,6 @@ impl std::fmt::Display for TimestampSuffix {
     }
 }
 
-#[cfg(feature = "time")]
 impl SuffixScheme for AppendTimestamp {
     type Repr = TimestampSuffix;
 
@@ -316,13 +304,12 @@ pub enum FileLimit {
     /// Delete the oldest files if number of files is too high
     MaxFiles(usize),
     /// Delete files whose age exceeds the `Duration` - age is determined by the suffix of the file
-    #[cfg(feature = "time")]
     Age(Duration),
     /// Never delete files
     Unlimited,
 }
 
-#[cfg(all(test, feature = "time"))]
+#[cfg(test)]
 mod test {
     use super::*;
     use std::fs::File;

--- a/src/suffix.rs
+++ b/src/suffix.rs
@@ -3,8 +3,10 @@
 //! This behaviour is fully extensible through the [SuffixScheme] trait, and two behaviours are
 //! provided: [AppendCount] and [AppendTimestamp]
 //!
+#[cfg(feature = "time")]
 use super::now;
 use crate::SuffixInfo;
+#[cfg(feature = "time")]
 use chrono::{format::ParseErrorKind, offset::Local, Duration, NaiveDateTime};
 use std::{
     cmp::Ordering,
@@ -156,6 +158,7 @@ pub enum DateFrom {
 /// Current limitations:
 ///  - Neither `format` nor the base filename can include the character `"."`.
 ///  - The `format` should ensure that the lexical and chronological orderings are the same
+#[cfg(feature = "time")]
 pub struct AppendTimestamp {
     /// The format of the timestamp suffix
     pub format: &'static str,
@@ -165,6 +168,7 @@ pub struct AppendTimestamp {
     pub date_from: DateFrom,
 }
 
+#[cfg(feature = "time")]
 impl AppendTimestamp {
     /// With format `"%Y%m%dT%H%M%S"`
     pub fn default(file_limit: FileLimit) -> Self {
@@ -217,6 +221,7 @@ impl std::fmt::Display for TimestampSuffix {
     }
 }
 
+#[cfg(feature = "time")]
 impl SuffixScheme for AppendTimestamp {
     type Repr = TimestampSuffix;
 
@@ -304,6 +309,7 @@ pub enum FileLimit {
     /// Delete the oldest files if number of files is too high
     MaxFiles(usize),
     /// Delete files whose age exceeds the `Duration` - age is determined by the suffix of the file
+    #[cfg(feature = "time")]
     Age(Duration),
     /// Never delete files
     Unlimited,
@@ -337,6 +343,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "time")]
     fn timestamp_scan_suffixes_base_paths() {
         let working_dir = TempDir::new().unwrap();
         let working_dir = working_dir.path().join("dir");
@@ -379,6 +386,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "time")]
     fn timestamp_scan_suffixes_formats() {
         struct TestCase {
             format: &'static str,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -344,7 +344,7 @@ fn unix_file_permissions() {
             &*log_path.to_string_lossy(),
             AppendCount::new(3),
             ContentLimit::Lines(2),
-            Compression::None,
+            #[cfg(feature = "compression")] Compression::None,
             Some(*permission),
         );
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -19,6 +19,7 @@ fn list(dir: &Path) {
 }
 
 #[test]
+#[cfg(feature = "time")]
 fn timestamp_max_files_rotation() {
     let tmp_dir = TempDir::new().unwrap();
     let log_path = tmp_dir.path().join("log");
@@ -27,9 +28,8 @@ fn timestamp_max_files_rotation() {
         &log_path,
         AppendTimestamp::default(FileLimit::MaxFiles(4)),
         ContentLimit::Lines(2),
-        Compression::None,
-        #[cfg(unix)]
-        None,
+        #[cfg(feature = "compression")] Compression::None,
+        #[cfg(unix)] None,
     );
 
     // Write 9 lines
@@ -113,9 +113,8 @@ fn count_max_files_rotation() {
         &*log_path.to_string_lossy(),
         AppendCount::new(4),
         ContentLimit::Lines(2),
-        Compression::None,
-        #[cfg(unix)]
-        None,
+        #[cfg(feature = "compression")] Compression::None,
+        #[cfg(unix)] None,
     );
 
     // Write 9 lines
@@ -155,9 +154,8 @@ fn rotate_to_deleted_directory() {
         &*log_path.to_string_lossy(),
         AppendCount::new(4),
         ContentLimit::Lines(1),
-        Compression::None,
-        #[cfg(unix)]
-        None,
+        #[cfg(feature = "compression")] Compression::None,
+        #[cfg(unix)] None,
     );
 
     write!(log, "a\nb\n").unwrap();
@@ -184,11 +182,10 @@ fn write_complete_record_until_bytes_surpassed() {
 
     let mut log = FileRotate::new(
         &log_path,
-        AppendTimestamp::default(FileLimit::MaxFiles(100)),
+        AppendCount::new(100),
         ContentLimit::BytesSurpassed(1),
-        Compression::None,
-        #[cfg(unix)]
-        None,
+        #[cfg(feature = "compression")] Compression::None,
+        #[cfg(unix)] None,
     );
 
     write!(log, "0123456789").unwrap();
@@ -204,6 +201,7 @@ fn write_complete_record_until_bytes_surpassed() {
 }
 
 #[test]
+#[cfg(feature = "compression")]
 fn compression_on_rotation() {
     let tmp_dir = TempDir::new().unwrap();
     let parent = tmp_dir.path();
@@ -213,8 +211,7 @@ fn compression_on_rotation() {
         AppendCount::new(3),
         ContentLimit::Lines(1),
         Compression::OnRotate(1), // Keep one file uncompressed
-        #[cfg(unix)]
-        None,
+        #[cfg(unix)] None,
     );
 
     writeln!(log, "A").unwrap();
@@ -257,9 +254,8 @@ fn no_truncate() {
             &*log_path.to_string_lossy(),
             AppendCount::new(3),
             ContentLimit::Lines(10000),
-            Compression::None,
-            #[cfg(unix)]
-            None,
+            #[cfg(feature = "compression")] Compression::None,
+            #[cfg(unix)] None,
         )
     };
     writeln!(file_rotate(), "A").unwrap();
@@ -284,9 +280,8 @@ fn byte_count_recalculation() {
         &*log_path.to_string_lossy(),
         AppendCount::new(3),
         ContentLimit::Bytes(2),
-        Compression::None,
-        #[cfg(unix)]
-        None,
+        #[cfg(feature = "compression")] Compression::None,
+        #[cfg(unix)] None,
     );
 
     write!(file_rotate, "bc").unwrap();
@@ -313,9 +308,8 @@ fn line_count_recalculation() {
         &*log_path.to_string_lossy(),
         AppendCount::new(3),
         ContentLimit::Lines(2),
-        Compression::None,
-        #[cfg(unix)]
-        None,
+        #[cfg(feature = "compression")] Compression::None,
+        #[cfg(unix)] None,
     );
 
     // A single line existed before the new logger ('a')
@@ -381,9 +375,8 @@ fn manual_rotation() {
         &*log_path.to_string_lossy(),
         AppendCount::new(3),
         ContentLimit::None,
-        Compression::None,
-        #[cfg(unix)]
-        None,
+        #[cfg(feature = "compression")] Compression::None,
+        #[cfg(unix)] None,
     );
     writeln!(log, "A").unwrap();
     log.rotate().unwrap();
@@ -407,11 +400,10 @@ fn arbitrary_lines(count: usize) {
     let count = count.max(1);
     let mut log = FileRotate::new(
         &log_path,
-        AppendTimestamp::default(FileLimit::MaxFiles(100)),
+        AppendCount::new(100),
         ContentLimit::Lines(count),
-        Compression::None,
-        #[cfg(unix)]
-        None,
+        #[cfg(feature = "compression")] Compression::None,
+        #[cfg(unix)] None,
     );
 
     for _ in 0..count - 1 {
@@ -433,11 +425,10 @@ fn arbitrary_bytes(count: usize) {
     let count = count.max(1);
     let mut log = FileRotate::new(
         &log_path,
-        AppendTimestamp::default(FileLimit::MaxFiles(100)),
+        AppendCount::new(100),
         ContentLimit::Bytes(count),
-        Compression::None,
-        #[cfg(unix)]
-        None,
+        #[cfg(feature = "compression")] Compression::None,
+        #[cfg(unix)] None,
     );
 
     for _ in 0..count {
@@ -451,6 +442,7 @@ fn arbitrary_bytes(count: usize) {
 }
 
 #[test]
+#[cfg(feature = "time")]
 fn rotate_by_time_frequency() {
     // Test time frequency by hours.
     test_time_frequency(
@@ -504,6 +496,7 @@ fn rotate_by_time_frequency() {
 }
 
 #[test]
+#[cfg(feature = "time")]
 fn test_file_limit() {
     let tmp_dir = TempDir::new().unwrap();
     let dir = tmp_dir.path();
@@ -520,9 +513,8 @@ fn test_file_limit() {
         log_path,
         AppendTimestamp::with_format("%Y-%m-%d", FileLimit::MaxFiles(1), DateFrom::DateYesterday),
         ContentLimit::Time(TimeFrequency::Daily),
-        Compression::None,
-        #[cfg(unix)]
-        None,
+        #[cfg(feature = "compression")] Compression::None,
+        #[cfg(unix)] None,
     );
 
     mock_time::set_mock_time(first);
@@ -549,9 +541,8 @@ fn test_panic() {
             &log_path,
             AppendCount::new(2),
             ContentLimit::None,
-            Compression::None,
-            #[cfg(unix)]
-            None,
+            #[cfg(feature = "compression")] Compression::None,
+            #[cfg(unix)] None,
         );
 
         write!(log, "nineteen characters").unwrap();
@@ -562,9 +553,8 @@ fn test_panic() {
         &log_path,
         AppendCount::new(2),
         ContentLimit::Bytes(8),
-        Compression::None,
-        #[cfg(unix)]
-        None,
+        #[cfg(feature = "compression")] Compression::None,
+        #[cfg(unix)] None,
     );
 
     write!(log, "0123").unwrap();
@@ -577,12 +567,14 @@ fn test_panic() {
     assert_eq!("0123", fs::read_to_string(&log_path).unwrap());
 }
 
+#[cfg(feature = "time")]
 fn get_fake_date_time(date_time: &str) -> DateTime<Local> {
     let date_obj = NaiveDateTime::parse_from_str(date_time, "%Y-%m-%dT%H:%M:%S");
 
     Local.from_local_datetime(&date_obj.unwrap()).unwrap()
 }
 
+#[cfg(feature = "time")]
 fn test_time_frequency(
     old_time: &str,
     second_old_time: &str,
@@ -604,9 +596,8 @@ fn test_time_frequency(
         &log_path,
         AppendTimestamp::with_format("%Y-%m-%d_%H-%M-%S", FileLimit::MaxFiles(7), date_from),
         ContentLimit::Time(frequency),
-        Compression::None,
-        #[cfg(unix)]
-        None,
+        #[cfg(feature = "compression")] Compression::None,
+        #[cfg(unix)] None,
     );
 
     writeln!(log, "a").unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -19,7 +19,6 @@ fn list(dir: &Path) {
 }
 
 #[test]
-#[cfg(feature = "time")]
 fn timestamp_max_files_rotation() {
     let tmp_dir = TempDir::new().unwrap();
     let log_path = tmp_dir.path().join("log");
@@ -28,8 +27,9 @@ fn timestamp_max_files_rotation() {
         &log_path,
         AppendTimestamp::default(FileLimit::MaxFiles(4)),
         ContentLimit::Lines(2),
-        #[cfg(feature = "compression")] Compression::None,
-        #[cfg(unix)] None,
+        Compression::None,
+        #[cfg(unix)]
+        None,
     );
 
     // Write 9 lines
@@ -113,8 +113,9 @@ fn count_max_files_rotation() {
         &*log_path.to_string_lossy(),
         AppendCount::new(4),
         ContentLimit::Lines(2),
-        #[cfg(feature = "compression")] Compression::None,
-        #[cfg(unix)] None,
+        Compression::None,
+        #[cfg(unix)]
+        None,
     );
 
     // Write 9 lines
@@ -154,8 +155,9 @@ fn rotate_to_deleted_directory() {
         &*log_path.to_string_lossy(),
         AppendCount::new(4),
         ContentLimit::Lines(1),
-        #[cfg(feature = "compression")] Compression::None,
-        #[cfg(unix)] None,
+        Compression::None,
+        #[cfg(unix)]
+        None,
     );
 
     write!(log, "a\nb\n").unwrap();
@@ -182,10 +184,11 @@ fn write_complete_record_until_bytes_surpassed() {
 
     let mut log = FileRotate::new(
         &log_path,
-        AppendCount::new(100),
+        AppendTimestamp::default(FileLimit::MaxFiles(100)),
         ContentLimit::BytesSurpassed(1),
-        #[cfg(feature = "compression")] Compression::None,
-        #[cfg(unix)] None,
+        Compression::None,
+        #[cfg(unix)]
+        None,
     );
 
     write!(log, "0123456789").unwrap();
@@ -201,7 +204,6 @@ fn write_complete_record_until_bytes_surpassed() {
 }
 
 #[test]
-#[cfg(feature = "compression")]
 fn compression_on_rotation() {
     let tmp_dir = TempDir::new().unwrap();
     let parent = tmp_dir.path();
@@ -211,7 +213,8 @@ fn compression_on_rotation() {
         AppendCount::new(3),
         ContentLimit::Lines(1),
         Compression::OnRotate(1), // Keep one file uncompressed
-        #[cfg(unix)] None,
+        #[cfg(unix)]
+        None,
     );
 
     writeln!(log, "A").unwrap();
@@ -254,8 +257,9 @@ fn no_truncate() {
             &*log_path.to_string_lossy(),
             AppendCount::new(3),
             ContentLimit::Lines(10000),
-            #[cfg(feature = "compression")] Compression::None,
-            #[cfg(unix)] None,
+            Compression::None,
+            #[cfg(unix)]
+            None,
         )
     };
     writeln!(file_rotate(), "A").unwrap();
@@ -280,8 +284,9 @@ fn byte_count_recalculation() {
         &*log_path.to_string_lossy(),
         AppendCount::new(3),
         ContentLimit::Bytes(2),
-        #[cfg(feature = "compression")] Compression::None,
-        #[cfg(unix)] None,
+        Compression::None,
+        #[cfg(unix)]
+        None,
     );
 
     write!(file_rotate, "bc").unwrap();
@@ -308,8 +313,9 @@ fn line_count_recalculation() {
         &*log_path.to_string_lossy(),
         AppendCount::new(3),
         ContentLimit::Lines(2),
-        #[cfg(feature = "compression")] Compression::None,
-        #[cfg(unix)] None,
+        Compression::None,
+        #[cfg(unix)]
+        None,
     );
 
     // A single line existed before the new logger ('a')
@@ -344,7 +350,7 @@ fn unix_file_permissions() {
             &*log_path.to_string_lossy(),
             AppendCount::new(3),
             ContentLimit::Lines(2),
-            #[cfg(feature = "compression")] Compression::None,
+            Compression::None,
             Some(*permission),
         );
 
@@ -375,8 +381,9 @@ fn manual_rotation() {
         &*log_path.to_string_lossy(),
         AppendCount::new(3),
         ContentLimit::None,
-        #[cfg(feature = "compression")] Compression::None,
-        #[cfg(unix)] None,
+        Compression::None,
+        #[cfg(unix)]
+        None,
     );
     writeln!(log, "A").unwrap();
     log.rotate().unwrap();
@@ -400,10 +407,11 @@ fn arbitrary_lines(count: usize) {
     let count = count.max(1);
     let mut log = FileRotate::new(
         &log_path,
-        AppendCount::new(100),
+        AppendTimestamp::default(FileLimit::MaxFiles(100)),
         ContentLimit::Lines(count),
-        #[cfg(feature = "compression")] Compression::None,
-        #[cfg(unix)] None,
+        Compression::None,
+        #[cfg(unix)]
+        None,
     );
 
     for _ in 0..count - 1 {
@@ -425,10 +433,11 @@ fn arbitrary_bytes(count: usize) {
     let count = count.max(1);
     let mut log = FileRotate::new(
         &log_path,
-        AppendCount::new(100),
+        AppendTimestamp::default(FileLimit::MaxFiles(100)),
         ContentLimit::Bytes(count),
-        #[cfg(feature = "compression")] Compression::None,
-        #[cfg(unix)] None,
+        Compression::None,
+        #[cfg(unix)]
+        None,
     );
 
     for _ in 0..count {
@@ -442,7 +451,6 @@ fn arbitrary_bytes(count: usize) {
 }
 
 #[test]
-#[cfg(feature = "time")]
 fn rotate_by_time_frequency() {
     // Test time frequency by hours.
     test_time_frequency(
@@ -496,7 +504,6 @@ fn rotate_by_time_frequency() {
 }
 
 #[test]
-#[cfg(feature = "time")]
 fn test_file_limit() {
     let tmp_dir = TempDir::new().unwrap();
     let dir = tmp_dir.path();
@@ -513,8 +520,9 @@ fn test_file_limit() {
         log_path,
         AppendTimestamp::with_format("%Y-%m-%d", FileLimit::MaxFiles(1), DateFrom::DateYesterday),
         ContentLimit::Time(TimeFrequency::Daily),
-        #[cfg(feature = "compression")] Compression::None,
-        #[cfg(unix)] None,
+        Compression::None,
+        #[cfg(unix)]
+        None,
     );
 
     mock_time::set_mock_time(first);
@@ -541,8 +549,9 @@ fn test_panic() {
             &log_path,
             AppendCount::new(2),
             ContentLimit::None,
-            #[cfg(feature = "compression")] Compression::None,
-            #[cfg(unix)] None,
+            Compression::None,
+            #[cfg(unix)]
+            None,
         );
 
         write!(log, "nineteen characters").unwrap();
@@ -553,8 +562,9 @@ fn test_panic() {
         &log_path,
         AppendCount::new(2),
         ContentLimit::Bytes(8),
-        #[cfg(feature = "compression")] Compression::None,
-        #[cfg(unix)] None,
+        Compression::None,
+        #[cfg(unix)]
+        None,
     );
 
     write!(log, "0123").unwrap();
@@ -567,14 +577,12 @@ fn test_panic() {
     assert_eq!("0123", fs::read_to_string(&log_path).unwrap());
 }
 
-#[cfg(feature = "time")]
 fn get_fake_date_time(date_time: &str) -> DateTime<Local> {
     let date_obj = NaiveDateTime::parse_from_str(date_time, "%Y-%m-%dT%H:%M:%S");
 
     Local.from_local_datetime(&date_obj.unwrap()).unwrap()
 }
 
-#[cfg(feature = "time")]
 fn test_time_frequency(
     old_time: &str,
     second_old_time: &str,
@@ -596,8 +604,9 @@ fn test_time_frequency(
         &log_path,
         AppendTimestamp::with_format("%Y-%m-%d_%H-%M-%S", FileLimit::MaxFiles(7), date_from),
         ContentLimit::Time(frequency),
-        #[cfg(feature = "compression")] Compression::None,
-        #[cfg(unix)] None,
+        Compression::None,
+        #[cfg(unix)]
+        None,
     );
 
     writeln!(log, "a").unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -25,7 +25,7 @@ fn timestamp_max_files_rotation() {
 
     let mut log = FileRotate::new(
         &log_path,
-        AppendTimestamp::default(FileLimit::MaxFiles(4)),
+        AppendCount::new(4),
         ContentLimit::Lines(2),
         Compression::None,
         None,
@@ -40,6 +40,7 @@ fn timestamp_max_files_rotation() {
     // Log names should be sorted. Low (old timestamp) to high (more recent timestamp)
     let mut log_paths_sorted = log_paths.clone();
     log_paths_sorted.sort();
+    log_paths_sorted.reverse();
     assert_eq!(log_paths, log_paths_sorted);
 
     assert_eq!("a\nb\n", fs::read_to_string(&log_paths[0]).unwrap());
@@ -54,6 +55,7 @@ fn timestamp_max_files_rotation() {
     assert_eq!(log_paths.len(), 4);
     let mut log_paths_sorted = log_paths.clone();
     log_paths_sorted.sort();
+    log_paths_sorted.reverse();
     assert_eq!(log_paths, log_paths_sorted);
 
     list(tmp_dir.path());
@@ -63,7 +65,9 @@ fn timestamp_max_files_rotation() {
     assert_eq!("k\nl\n", fs::read_to_string(&log_paths[3]).unwrap());
     assert_eq!("m\n", fs::read_to_string(&log_path).unwrap());
 }
+
 #[test]
+#[cfg(feature = "time")]
 fn timestamp_max_age_deletion() {
     // In order not to have to sleep, and keep it deterministic, let's already create the log files and see how FileRotate
     // cleans up the old ones.
@@ -177,7 +181,7 @@ fn write_complete_record_until_bytes_surpassed() {
 
     let mut log = FileRotate::new(
         &log_path,
-        AppendTimestamp::default(FileLimit::MaxFiles(100)),
+        AppendCount::new(100),
         ContentLimit::BytesSurpassed(1),
         Compression::None,
         None,
@@ -215,6 +219,7 @@ fn compression_on_rotation() {
 
     let log_paths = log.log_paths();
 
+    #[cfg(feature = "compression")]
     assert_eq!(
         log_paths,
         vec![
@@ -224,14 +229,32 @@ fn compression_on_rotation() {
         ]
     );
 
+    #[cfg(not(feature = "compression"))]
+    assert_eq!(
+        log_paths,
+        vec![
+            parent.join("log.3"),
+            parent.join("log.2"),
+            parent.join("log.1"),
+        ]
+    );
+
+
     assert_eq!("", fs::read_to_string(&log_path).unwrap());
 
+    #[cfg(feature = "compression")]
     fn compress(text: &str) -> Vec<u8> {
         let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
 
         encoder.write_all(text.as_bytes()).unwrap();
         encoder.finish().unwrap()
     }
+
+    #[cfg(not(feature = "compression"))]
+    fn compress(text: &str) -> Vec<u8> {
+        text.as_bytes().to_vec()
+    }
+
     assert_eq!(compress("A\n"), fs::read(&log.log_paths()[0]).unwrap());
     assert_eq!(compress("B\n"), fs::read(&log.log_paths()[1]).unwrap());
     assert_eq!("C\n", fs::read_to_string(&log.log_paths()[2]).unwrap());
@@ -402,7 +425,7 @@ fn arbitrary_lines(count: usize) {
     let count = count.max(1);
     let mut log = FileRotate::new(
         &log_path,
-        AppendTimestamp::default(FileLimit::MaxFiles(100)),
+        AppendCount::new(100),
         ContentLimit::Lines(count),
         Compression::None,
         None,
@@ -427,7 +450,7 @@ fn arbitrary_bytes(count: usize) {
     let count = count.max(1);
     let mut log = FileRotate::new(
         &log_path,
-        AppendTimestamp::default(FileLimit::MaxFiles(100)),
+        AppendCount::new(100),
         ContentLimit::Bytes(count),
         Compression::None,
         None,
@@ -444,6 +467,7 @@ fn arbitrary_bytes(count: usize) {
 }
 
 #[test]
+#[cfg(feature = "time")]
 fn rotate_by_time_frequency() {
     // Test time frequency by hours.
     test_time_frequency(
@@ -497,6 +521,7 @@ fn rotate_by_time_frequency() {
 }
 
 #[test]
+#[cfg(feature = "time")]
 fn test_file_limit() {
     let tmp_dir = TempDir::new().unwrap();
     let dir = tmp_dir.path();
@@ -567,12 +592,14 @@ fn test_panic() {
     assert_eq!("0123", fs::read_to_string(&log_path).unwrap());
 }
 
+#[cfg(feature = "time")]
 fn get_fake_date_time(date_time: &str) -> DateTime<Local> {
     let date_obj = NaiveDateTime::parse_from_str(date_time, "%Y-%m-%dT%H:%M:%S");
 
     Local.from_local_datetime(&date_obj.unwrap()).unwrap()
 }
 
+#[cfg(feature = "time")]
 fn test_time_frequency(
     old_time: &str,
     second_old_time: &str,


### PR DESCRIPTION
This makes the `chrono` and `flate2` dependencies optional, adding a `time` and `compression` feature for each. These features are enabled by default, but can be disabled by using `default-features = false` in the Cargo.toml dependency definition, allowing library users to opt out of these dependencies if they don't need them. 

This should slightly reduce compile times and measurably reduce binary size. In my testing on a release build I saved 72.5 KiB of binary size by dropping these features from a project that depends on file-rotate, but doesn't need compression or time-based log rotation. Using fat LTO also does not solve the size bloat: it just reduces it down to 66 KiB. These filesize savings may not sound like much, but size bloat adds up quickly across multiple dependencies.

`cfg` attributes have been added to tests to support testing with features disabled, and I've added additional test runs in the rust.yml GitHub Action to cover these cases. The example and doc tests only work with the default features enabled, but I think that's fine. I've tested locally and the tests pass for all four possible feature enablement configurations. If you want me to add additional cargo check runs for these cases let me know and I'll do that as well, but I think that may just slow down the GitHub Action CI time unnecessarily.

I have not bumped the library version in Cargo.toml as I believe that should be left to the maintainer. However, note that a major version bump is needed (e.g. 0.7.6 -> 0.8.0) as this change is breaking for anyone already using `default-features = false` (even though there are currently no features someone may still be doing this). I've seen other projects get hit by this, and affected library users typically call for a cargo yank.

Also, I must apologize because I only noticed  *after* I made this change that you already changed the chrono dependency from optional to mandatory last year as part of #24. If optional dependencies aren't something you're interested in merging I understand, but I figure I might as well open the PR seeing as it's done.
