### PR TITLE
Add optional file ownership parameter for file creation (mac only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ use file_rotate::{FileRotate, ContentLimit, compression::Compression, suffix::Ap
 use std::{fs, io::Write, path::PathBuf};
 
 fn main() {
-    let mut log = FileRotate::new("logs/log", AppendCount::new(2), ContentLimit::Lines(3), Compression::None, None);
+    let mut log = FileRotate::new("logs/log", AppendCount::new(2), ContentLimit::Lines(3), Compression::None, None, None);
 
     // Write a bunch of lines
     writeln!(log, "Line 1: Hello World!");
@@ -52,6 +52,7 @@ let mut log = FileRotate::new(
     AppendTimestamp::default(FileLimit::MaxFiles(3)),
     ContentLimit::Lines(3),
     Compression::None,
+    None,
     None,
 );
 

--- a/examples/rotate_by_date.rs
+++ b/examples/rotate_by_date.rs
@@ -12,6 +12,7 @@ fn main() {
         ContentLimit::Time(TimeFrequency::Daily),
         Compression::None,
         None,
+        None,
     );
 
     // Write a bunch of lines

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //!     ContentLimit::Lines(3),
 //!     Compression::None,
 //!     None,
+//!     None,
 //! );
 //!
 //! // Write a bunch of lines
@@ -61,6 +62,7 @@
 //!     AppendCount::new(2),
 //!     ContentLimit::Bytes(5),
 //!     Compression::None,
+//!     None,
 //!     None,
 //! );
 //!
@@ -97,6 +99,7 @@
 //!     AppendCount::new(3),
 //!     ContentLimit::Bytes(1),
 //!     Compression::None,
+//!     None,
 //!     None,
 //! );
 //!
@@ -156,6 +159,7 @@
 //!     ContentLimit::Bytes(1),
 //!     Compression::None,
 //!     None,
+//!     None,
 //! );
 //!
 //! write!(log, "A");
@@ -200,6 +204,7 @@
 //!     AppendTimestamp::default(FileLimit::MaxFiles(4)),
 //!     ContentLimit::Bytes(1),
 //!     Compression::OnRotate(2),
+//!     None,
 //!     None,
 //! );
 //!
@@ -295,6 +300,7 @@ use std::{
     fs::{self, File, OpenOptions},
     io::{self, Write},
     path::{Path, PathBuf},
+    process::Command,
 };
 use suffix::*;
 
@@ -333,6 +339,15 @@ pub enum ContentLimit {
     BytesSurpassed(usize),
     /// Don't do any rotation automatically
     None,
+}
+
+/// Ownership of the file (mac only for now)
+#[derive(Debug)]
+pub struct FileOwnership {
+    /// User name or UID
+    pub owner: Option<String>,
+    /// Group name or GID
+    pub group: Option<String>,
 }
 
 /// Used mostly internally. Info about suffix + compressed state.
@@ -385,6 +400,7 @@ pub struct FileRotate<S: SuffixScheme> {
     /// The bool is whether or not there's a .gz suffix to the filename
     suffixes: BTreeSet<SuffixInfo<S::Repr>>,
     open_options: Option<OpenOptions>,
+    file_ownership: Option<FileOwnership>,
 }
 
 impl<S: SuffixScheme> FileRotate<S> {
@@ -406,6 +422,7 @@ impl<S: SuffixScheme> FileRotate<S> {
         content_limit: ContentLimit,
         compression: Compression,
         open_options: Option<OpenOptions>,
+        file_ownership: Option<FileOwnership>,
     ) -> Self {
         match content_limit {
             ContentLimit::Bytes(bytes) => {
@@ -434,12 +451,31 @@ impl<S: SuffixScheme> FileRotate<S> {
             suffixes: BTreeSet::new(),
             suffix_scheme,
             open_options,
+            file_ownership,
         };
         s.ensure_log_directory_exists();
         s.scan_suffixes();
 
         s
     }
+
+    fn change_ownership(&self) -> io::Result<()> {
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(ref ownership) = self.file_ownership {
+                let path = &self.basepath;
+
+                if let (Some(owner), Some(group)) = (&ownership.owner, &ownership.group) {
+                    Command::new("chown")
+                        .arg(format!("{}:{}", owner, group))
+                        .arg(path)
+                        .output()?;
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn ensure_log_directory_exists(&mut self) {
         let path = self.basepath.parent().unwrap();
         if !path.exists() {
@@ -449,6 +485,11 @@ impl<S: SuffixScheme> FileRotate<S> {
         if !self.basepath.exists() || self.file.is_none() {
             // Open or create the file
             self.open_file();
+
+            // Change ownership if specified
+            if let Err(e) = self.change_ownership() {
+                eprintln!("Failed to change ownership: {}", e);
+            }
 
             match self.file {
                 None => self.count = 0,
@@ -569,6 +610,11 @@ impl<S: SuffixScheme> FileRotate<S> {
         self.suffixes.insert(new_suffix_info);
 
         self.open_file();
+
+        // Change ownership if specified
+        if let Err(e) = self.change_ownership() {
+            eprintln!("Failed to change ownership: {}", e);
+        }
 
         self.count = 0;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -29,6 +29,7 @@ fn timestamp_max_files_rotation() {
         ContentLimit::Lines(2),
         Compression::None,
         None,
+        None,
     );
 
     // Write 9 lines
@@ -84,6 +85,7 @@ fn timestamp_max_age_deletion() {
         ContentLimit::Lines(1),
         Compression::None,
         None,
+        None,
     );
     writeln!(log, "trigger\nat\nleast\none\nrotation").unwrap();
 
@@ -109,6 +111,7 @@ fn count_max_files_rotation() {
         AppendCount::new(4),
         ContentLimit::Lines(2),
         Compression::None,
+        None,
         None,
     );
 
@@ -151,6 +154,7 @@ fn rotate_to_deleted_directory() {
         ContentLimit::Lines(1),
         Compression::None,
         None,
+        None,
     );
 
     write!(log, "a\nb\n").unwrap();
@@ -181,6 +185,7 @@ fn write_complete_record_until_bytes_surpassed() {
         ContentLimit::BytesSurpassed(1),
         Compression::None,
         None,
+        None,
     );
 
     write!(log, "0123456789").unwrap();
@@ -205,6 +210,7 @@ fn compression_on_rotation() {
         AppendCount::new(3),
         ContentLimit::Lines(1),
         Compression::OnRotate(1), // Keep one file uncompressed
+        None,
         None,
     );
 
@@ -250,6 +256,7 @@ fn no_truncate() {
             ContentLimit::Lines(10000),
             Compression::None,
             None,
+            None,
         )
     };
     writeln!(file_rotate(), "A").unwrap();
@@ -275,6 +282,7 @@ fn byte_count_recalculation() {
         AppendCount::new(3),
         ContentLimit::Bytes(2),
         Compression::None,
+        None,
         None,
     );
 
@@ -303,6 +311,7 @@ fn line_count_recalculation() {
         AppendCount::new(3),
         ContentLimit::Lines(2),
         Compression::None,
+        None,
         None,
     );
 
@@ -348,6 +357,7 @@ fn unix_file_permissions() {
             ContentLimit::Lines(2),
             Compression::None,
             Some(options),
+            None,
         );
 
         // Trigger a rotation by writing three lines
@@ -379,6 +389,7 @@ fn manual_rotation() {
         ContentLimit::None,
         Compression::None,
         None,
+        None,
     );
     writeln!(log, "A").unwrap();
     log.rotate().unwrap();
@@ -406,6 +417,7 @@ fn arbitrary_lines(count: usize) {
         ContentLimit::Lines(count),
         Compression::None,
         None,
+        None,
     );
 
     for _ in 0..count - 1 {
@@ -430,6 +442,7 @@ fn arbitrary_bytes(count: usize) {
         AppendTimestamp::default(FileLimit::MaxFiles(100)),
         ContentLimit::Bytes(count),
         Compression::None,
+        None,
         None,
     );
 
@@ -515,6 +528,7 @@ fn test_file_limit() {
         ContentLimit::Time(TimeFrequency::Daily),
         Compression::None,
         None,
+        None,
     );
 
     mock_time::set_mock_time(first);
@@ -543,6 +557,7 @@ fn test_panic() {
             ContentLimit::None,
             Compression::None,
             None,
+            None,
         );
 
         write!(log, "nineteen characters").unwrap();
@@ -554,6 +569,7 @@ fn test_panic() {
         AppendCount::new(2),
         ContentLimit::Bytes(8),
         Compression::None,
+        None,
         None,
     );
 
@@ -595,6 +611,7 @@ fn test_time_frequency(
         AppendTimestamp::with_format("%Y-%m-%d_%H-%M-%S", FileLimit::MaxFiles(7), date_from),
         ContentLimit::Time(frequency),
         Compression::None,
+        None,
         None,
     );
 


### PR DESCRIPTION
In regards to [issue 32](https://github.com/kstrafe/file-rotate/issues/32). Want to add the ability to change group and ownership on mac. 

This can either be implemented in a [callback](https://github.com/kstrafe/file-rotate/compare/master...craigdub:file-rotate:implement-file-create-rotate-callback?expand=1) function or as an ownership parameter that is only supported for specific OS.

Let me know what you think.